### PR TITLE
Handle signals while trying to connect

### DIFF
--- a/sensu/client.go
+++ b/sensu/client.go
@@ -49,8 +49,12 @@ func (c *Client) Start() error {
 		c.Transport.Connect()
 
 		for !c.Transport.IsConnected() {
-			time.Sleep(CONNECTION_TIMEOUT)
-			c.Transport.Connect()
+			select {
+			case <-time.After(CONNECTION_TIMEOUT):
+				c.Transport.Connect()
+			case <-sig:
+				return c.Transport.Close()
+			}
 		}
 
 		processors := c.buildProcessors()


### PR DESCRIPTION
Now it is possible to interrupt the client when there is no possibility of connecting to RabbitMQ.

```
~/sensu-client-go$ ./sensu-client-go 
2015/08/11 05:18:10 RabbitMQ connection error : dial tcp 127.0.0.1:5672: connection refused
2015/08/11 05:18:15 RabbitMQ connection error : dial tcp 127.0.0.1:5672: connection refused
^C
~/sensu-client-go$
```
