### PR TITLE
Fix occasional test failures

### DIFF
--- a/sensu/check/extension_check_test.go
+++ b/sensu/check/extension_check_test.go
@@ -21,7 +21,7 @@ func TestExtension(t *testing.T) {
 		t.Errorf("Wrong output: %s", r.Output)
 	}
 
-	if r.Duration <= 0.0 {
+	if r.Duration < 0.0 {
 		t.Errorf("The duration is not positive: %f", r.Duration)
 	}
 }

--- a/sensu/check/external_check_test.go
+++ b/sensu/check/external_check_test.go
@@ -15,7 +15,7 @@ func TestEmptyCommand(t *testing.T) {
 		t.Errorf("The status is not failed, %d", r.Status)
 	}
 
-	if r.Duration <= 0.0 {
+	if r.Duration < 0.0 {
 		t.Errorf("The duration is not positive: %f", r.Duration)
 	}
 }
@@ -29,7 +29,7 @@ func TestCorrectCommand(t *testing.T) {
 		t.Errorf("The status is not success, %d", r.Status)
 	}
 
-	if r.Duration <= 0.0 {
+	if r.Duration < 0.0 {
 		t.Errorf("The duration is not positive: %f", r.Duration)
 	}
 }
@@ -43,7 +43,7 @@ func TestOtherExitCodeCommand(t *testing.T) {
 		t.Errorf("The status is not success, %d", r.Status)
 	}
 
-	if r.Duration <= 0.0 {
+	if r.Duration < 0.0 {
 		t.Errorf("The duration is not positive: %f", r.Duration)
 	}
 }


### PR DESCRIPTION
For some reason, if tests execute too fast, the duration of checks ends up equal to 0.0, causing tests to fail sometimes.

I believe there is no value in comparing the duration to 0, so testing that duration < 0.0 should be sufficient.