### PR TITLE
add workaround/option to select Sensu config file from within tool

### DIFF
--- a/sensu/config.go
+++ b/sensu/config.go
@@ -2,6 +2,7 @@ package sensu
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -48,6 +49,20 @@ func split(str string, token string) []string {
 	return strings.Split(str, token)
 }
 
+func NewConfigFromFile(flagset *configFlagSet, configFile string) (*Config, error) {
+	var cfg = Config{flagset, &configPayload{}}
+	buf, err := ioutil.ReadFile(configFile)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(buf, &cfg.config); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
 func NewConfigFromFlagSet(flagset *configFlagSet) (*Config, error) {
 	var cfg = Config{flagset, &configPayload{}}
 
@@ -61,9 +76,10 @@ func NewConfigFromFlagSet(flagset *configFlagSet) (*Config, error) {
 		if err := json.Unmarshal(buf, &cfg.config); err != nil {
 			return nil, err
 		}
+		return &cfg, nil
 	}
+	return nil, errors.New("No config file is set")
 
-	return &cfg, nil
 }
 
 func (c *Config) RabbitMQURI() string {

--- a/sensu/config.go
+++ b/sensu/config.go
@@ -65,11 +65,8 @@ func NewConfigFromFile(flagset *configFlagSet, configFile string) (*Config, erro
 func NewConfigFromFlagSet(flagset *configFlagSet) (*Config, error) {
 	if flagset != nil && flagset.configFile != "" {
 		return NewConfigFromFile(flagset, flagset.configFile)
-	} else {
-		var cfg = Config{flagset, &configPayload{}}
-		return &cfg, nil
 	}
-
+	return &Config{flagset, &configPayload{}}, nil
 }
 
 func (c *Config) RabbitMQURI() string {

--- a/sensu/config.go
+++ b/sensu/config.go
@@ -2,7 +2,6 @@ package sensu
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -50,7 +49,7 @@ func split(str string, token string) []string {
 }
 
 func NewConfigFromFile(flagset *configFlagSet, configFile string) (*Config, error) {
-	var cfg = Config{flagset, &configPayload{}}
+	cfg := Config{flagset, &configPayload{}}
 	buf, err := ioutil.ReadFile(configFile)
 
 	if err != nil {
@@ -64,21 +63,16 @@ func NewConfigFromFile(flagset *configFlagSet, configFile string) (*Config, erro
 }
 
 func NewConfigFromFlagSet(flagset *configFlagSet) (*Config, error) {
-	var cfg = Config{flagset, &configPayload{}}
-
 	if flagset != nil && flagset.configFile != "" {
-		buf, err := ioutil.ReadFile(flagset.configFile)
-
+		cfg, err := NewConfigFromFile(flagset, flagset.configFile)
 		if err != nil {
 			return nil, err
 		}
-
-		if err := json.Unmarshal(buf, &cfg.config); err != nil {
-			return nil, err
-		}
+		return cfg, nil
+	} else {
+		var cfg = Config{flagset, &configPayload{}}
 		return &cfg, nil
 	}
-	return nil, errors.New("No config file is set")
 
 }
 

--- a/sensu/config.go
+++ b/sensu/config.go
@@ -64,11 +64,7 @@ func NewConfigFromFile(flagset *configFlagSet, configFile string) (*Config, erro
 
 func NewConfigFromFlagSet(flagset *configFlagSet) (*Config, error) {
 	if flagset != nil && flagset.configFile != "" {
-		cfg, err := NewConfigFromFile(flagset, flagset.configFile)
-		if err != nil {
-			return nil, err
-		}
-		return cfg, nil
+		return NewConfigFromFile(flagset, flagset.configFile)
 	} else {
 		var cfg = Config{flagset, &configPayload{}}
 		return &cfg, nil


### PR DESCRIPTION
I am using your sensu-client-go package to extend one of our tools to also run as a standalone sensu check.  Since the tool already has command line flags I wasn't able to set the Sensu configuration file from the command line as the NewConfigFromFlagSet function expects.

- Return error in NewConfigFromFlagSet if flagset.configFile is not set
- Add exported function to set the Sensu config file from within the context of the tool to allow for setting the Sensu config file location